### PR TITLE
Add profile screen with logout and delete actions

### DIFF
--- a/src/components/mainNavigator/MainNavigator.jsx
+++ b/src/components/mainNavigator/MainNavigator.jsx
@@ -9,6 +9,7 @@ import VerificationScreen from "@screens/VerificationScreen";
 import ChangePasswordScreen from "@screens/ChangePasswordScreen";
 import ButtonExamples from "@screens/ButtonExamples";
 import OnboardingScreen from "@screens/OnboardingScreen";
+import ProfileScreen from "@screens/ProfileScreen";
 import supabase from "@config/supabase";
 
 
@@ -50,6 +51,7 @@ const MainNavigator = () => {
             <Stack.Screen name="VerificationScreen" component={VerificationScreen} />
             <Stack.Screen name="ButtonExamples" component={ButtonExamples} />
             <Stack.Screen name="ChangePasswordScreen" component={ChangePasswordScreen} />
+            <Stack.Screen name="ProfileScreen" component={ProfileScreen} />
           </>
         ) : (
           <>

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -19,10 +19,16 @@ const HomeScreen = ({navigation}) => {
                 size="small"
                 onPress={() => navigation.navigate('ButtonExamples')}
             />
-        <Button 
+        <Button
             title="Change Password"
             onPress={() => {navigation.navigate('ChangePasswordScreen')}}
             variant="secondary"
+            size="small"
+        />
+        <Button
+            title="View Profile"
+            onPress={() => {navigation.navigate('ProfileScreen')}}
+            variant="primary"
             size="small"
         />
         </View>

--- a/src/screens/ProfileScreen.jsx
+++ b/src/screens/ProfileScreen.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, View, Text, StyleSheet, Alert } from 'react-native';
+import Button from '@components/buttons/Button';
+import supabase from '@config/supabase';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ProfileScreen = ({ navigation }) => {
+  const [email, setEmail] = useState('');
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data, error } = await supabase.auth.getUser();
+      if (!error && data?.user?.email) {
+        setEmail(data.user.email);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    await AsyncStorage.removeItem('userUuid');
+    navigation.replace('SignInScreen');
+  };
+
+  const handleDeleteAccount = async () => {
+    const { data } = await supabase.auth.getUser();
+    const userId = data?.user?.id;
+    if (!userId) return;
+    const { error } = await supabase.auth.admin.deleteUser(userId);
+    if (error) {
+      Alert.alert('Error', error.message);
+      return;
+    }
+    await supabase.auth.signOut();
+    await AsyncStorage.removeItem('userUuid');
+    navigation.replace('SignUpScreen');
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.header}>Profile</Text>
+      {email ? <Text style={styles.email}>{email}</Text> : null}
+      <View style={styles.buttonContainer}>
+        <Button title="Log Out" variant="secondary" onPress={handleLogout} />
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button title="Delete Account" variant="outline" onPress={handleDeleteAccount} />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: '500',
+    marginBottom: 12,
+  },
+  email: {
+    fontSize: 16,
+    marginBottom: 24,
+  },
+  buttonContainer: {
+    width: '100%',
+    marginVertical: 6,
+  },
+});
+
+export default ProfileScreen;


### PR DESCRIPTION
## Summary
- add new `ProfileScreen` with logout and delete account functions
- update navigator to include new screen
- add button on home screen to open profile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68694fc4be08832b82594634dafedd46